### PR TITLE
Fixes bad return type

### DIFF
--- a/src/Http/Middleware/Authorize.php
+++ b/src/Http/Middleware/Authorize.php
@@ -12,7 +12,7 @@ class Authorize
     /**
      * Handle the incoming request.
      */
-    public function handle(Request $request, Closure $next): Response
+    public function handle(Request $request, Closure $next): mixed
     {
         return resolve(Google2fa::class)->authorize($request) ? $next($request) : abort(403);
     }


### PR DESCRIPTION
VinsanityShred\Google2fa\Http\Middleware\Authorize::handle(): Return value must be of type Illuminate\Http\Response, Illuminate\Http\RedirectResponse returned